### PR TITLE
Correção para pedidos antigos

### DIFF
--- a/app/design/adminhtml/base/default/template/MOIP/onestepcheckout/sales/order/view/tab/info/Customermessages.phtml
+++ b/app/design/adminhtml/base/default/template/MOIP/onestepcheckout/sales/order/view/tab/info/Customermessages.phtml
@@ -1,18 +1,25 @@
-<?php 
+<?php
 
 $_order = Mage::registry('current_order');
 $orderid=$_order->getId();
 $orders=Mage::getModel('onestepcheckout/onestepcheckout')->getCollection()->addFieldToFilter('sales_order_id',$orderid);
 $class_orders=get_class($orders);	
-$o ='';
+$o = '';
+$comment = '';
 
-foreach($orders as $order)	
-{
-	$o = $order; break;		
-}
+if (count($orders) != 0):
+
+	foreach($orders as $order)	
+	{
+		$o = $order; break;		
+	}
+
+	$comment = $o->getMoipCustomercommentInfo();
+
+endif
 ?>
 
-<?php if($o->getMoipCustomercommentInfo()):?>
+<?php if($comment != ''): ?>
 <div class="box-right">
 	<div class="entry-edit">
 		<div class="entry-edit-head">
@@ -20,10 +27,10 @@ foreach($orders as $order)
 		</div>
 		<fieldset>
 		
-			<?php echo $o->getMoipCustomercommentInfo(); ?>
+			<?php echo nl2br($comment, 1); ?>
 		
 		</fieldset>
 	</div>
 </div>
 <div class="clear"></div>
-<?php endif?>
+<?php endif ?>

--- a/app/design/adminhtml/default/default/template/MOIP/onestepcheckout/sales/order/view/tab/info/Customermessages.phtml
+++ b/app/design/adminhtml/default/default/template/MOIP/onestepcheckout/sales/order/view/tab/info/Customermessages.phtml
@@ -1,18 +1,25 @@
-<?php 
+<?php
 
 $_order = Mage::registry('current_order');
 $orderid=$_order->getId();
 $orders=Mage::getModel('onestepcheckout/onestepcheckout')->getCollection()->addFieldToFilter('sales_order_id',$orderid);
 $class_orders=get_class($orders);	
-$o ='';
+$o = '';
+$comment = '';
 
-foreach($orders as $order)	
-{
-	$o = $order; break;		
-}
+if (count($orders) != 0):
+
+	foreach($orders as $order)	
+	{
+		$o = $order; break;		
+	}
+
+	$comment = $o->getMoipCustomercommentInfo();
+
+endif
 ?>
 
-<?php if($o->getMoipCustomercommentInfo()):?>
+<?php if($comment != ''): ?>
 <div class="box-right">
 	<div class="entry-edit">
 		<div class="entry-edit-head">
@@ -20,10 +27,10 @@ foreach($orders as $order)
 		</div>
 		<fieldset>
 		
-			<?php echo $o->getMoipCustomercommentInfo(); ?>
+			<?php echo nl2br($comment, 1); ?>
 		
 		</fieldset>
 	</div>
 </div>
 <div class="clear"></div>
-<?php endif?>
+<?php endif ?>


### PR DESCRIPTION
Corrige bug de montagem da página para pedidos anteriores à implantação do módulo.
A página quebrada não mostra nenhuma informação do pedido.
A correção avalia a existência do pedido na tabela moip_onestepcheckout antes de pegar o comentário do cliente.