### PR TITLE
Removido inconsistências e ajustado limites de campos

### DIFF
--- a/app/code/local/MOIP/Onestepcheckout/Helper/Data.php
+++ b/app/code/local/MOIP/Onestepcheckout/Helper/Data.php
@@ -45,17 +45,17 @@ class MOIP_Onestepcheckout_Helper_Data extends Mage_Core_Helper_Abstract
                                     'street_3'  => '0',
                                     'street_4'  => '1',
                                     'telephone' => '10',
-                                    
+
                                     //'region_id' => '1'
                                 );
         $validatevaluesMax = array(
                                     'postcode'  => '9',
-                                    'street_1'  => '45',
+                                    'street_1'  => '57',
                                     'street_2'  => '6',
                                     'street_3'  => '30',
                                     'street_4'  => '60',
                                     'telephone' => '14',
-                                    
+
                                     //'region_id' => '99999'
                                 );
         if($key != 'street_3'){

--- a/app/code/local/MOIP/Onestepcheckout/Helper/Data.php
+++ b/app/code/local/MOIP/Onestepcheckout/Helper/Data.php
@@ -51,7 +51,7 @@ class MOIP_Onestepcheckout_Helper_Data extends Mage_Core_Helper_Abstract
         $validatevaluesMax = array(
                                     'postcode'  => '9',
                                     'street_1'  => '45',
-                                    'street_2'  => '5',
+                                    'street_2'  => '6',
                                     'street_3'  => '30',
                                     'street_4'  => '60',
                                     'telephone' => '14',

--- a/app/design/frontend/base/default/template/MOIP/onestepcheckout/cadastro/billing/billingform.phtml
+++ b/app/design/frontend/base/default/template/MOIP/onestepcheckout/cadastro/billing/billingform.phtml
@@ -217,7 +217,7 @@
                     <div class="form-group">
                           <label class="col-sm-12 control-label" for="textinput">Rua</label>  
                           <div class="col-sm-12">
-                                <input   type="text" title="Endereço da rua" name="billing[street][0]" id="billing:street1" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(1)) ?>" class=" form-control   required-entry  validate-length minimum-length-4 maximum-length-65" placeholder="Endereço">
+                                <input type="text" title="Endereço da rua" name="billing[street][0]" id="billing:street1" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(1)) ?>" class="form-control required-entry validate-length minimum-length-4 maximum-length-57" placeholder="Endereço">
                           </div>
                     </div>
                 </div>

--- a/app/design/frontend/base/default/template/MOIP/onestepcheckout/cadastro/billing/billingform.phtml
+++ b/app/design/frontend/base/default/template/MOIP/onestepcheckout/cadastro/billing/billingform.phtml
@@ -227,7 +227,7 @@
                     <div class="form-group">
                           <label class="col-sm-12 control-label" for="textinput">Número</label>
                           <div class="col-sm-12">
-                                <input   type="tel" title="Número" name="billing[street][1]" id="billing:street2" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(2)) ?>" class=" form-control   required-entry  validate-length minimum-length-1 maximum-length-5" placeholder="Número">
+                                <input type="tel" title="Número" name="billing[street][1]" id="billing:street2" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(2)) ?>" class="form-control required-entry validate-length minimum-length-1 maximum-length-6" placeholder="Número">
                           </div>
                     </div>
                 </div>

--- a/app/design/frontend/base/default/template/MOIP/onestepcheckout/checkout/daskboard/onepage/billing/billingform.phtml
+++ b/app/design/frontend/base/default/template/MOIP/onestepcheckout/checkout/daskboard/onepage/billing/billingform.phtml
@@ -237,7 +237,7 @@
                     <div class="form-group">
                           <label class="col-sm-12 control-label" for="textinput">Número</label>
                           <div class="col-sm-12">
-                                <input   type="tel" title="Número" name="billing[street][1]" id="billing:street2" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(2)) ?>" class=" form-control   required-entry  validate-length minimum-length-1 maximum-length-5" placeholder="Número">
+                                <input type="tel" title="Número" name="billing[street][1]" id="billing:street2" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(2)) ?>" class="form-control required-entry validate-length minimum-length-1 maximum-length-6" placeholder="Número">
                           </div>
                     </div>
                 </div>

--- a/app/design/frontend/base/default/template/MOIP/onestepcheckout/checkout/daskboard/onepage/billing/billingform.phtml
+++ b/app/design/frontend/base/default/template/MOIP/onestepcheckout/checkout/daskboard/onepage/billing/billingform.phtml
@@ -227,7 +227,7 @@
                     <div class="form-group">
                           <label class="col-sm-12 control-label" for="textinput">Rua</label>  
                           <div class="col-sm-12">
-                                <input   type="text" title="Endereço da rua" name="billing[street][0]" id="billing:street1" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(1)) ?>" class=" form-control   required-entry  validate-length minimum-length-4 maximum-length-45" placeholder="Endereço">
+                                <input   type="text" title="Endereço da rua" name="billing[street][0]" id="billing:street1" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(1)) ?>" class=" form-control   required-entry  validate-length minimum-length-4 maximum-length-57" placeholder="Endereço">
                           </div>
                     </div>
                 </div>

--- a/app/design/frontend/base/default/template/MOIP/onestepcheckout/checkout/daskboard/onepage/shipping/shipping_form.phtml
+++ b/app/design/frontend/base/default/template/MOIP/onestepcheckout/checkout/daskboard/onepage/shipping/shipping_form.phtml
@@ -86,7 +86,7 @@
                 <div class="form-group">
                       <label class="col-sm-12 control-label" for="textinput">Número</label>
                       <div class="col-sm-12">
-                            <input   type="tel" title="Número" name="shipping[street][1]" id="shipping:street2" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(2)) ?>" class=" form-control   required-entry  validate-length minimum-length-1 maximum-length-5" placeholder="Número">
+                            <input type="tel" title="Número" name="shipping[street][1]" id="shipping:street2" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(2)) ?>" class="form-control required-entry validate-length minimum-length-1 maximum-length-6" placeholder="Número">
                       </div>
                 </div>
               </div>

--- a/app/design/frontend/base/default/template/MOIP/onestepcheckout/editaddress/billing/billingform.phtml
+++ b/app/design/frontend/base/default/template/MOIP/onestepcheckout/editaddress/billing/billingform.phtml
@@ -195,7 +195,7 @@
                     <div class="form-group">
                           <label class="col-sm-12 control-label" for="textinput">Rua</label>  
                           <div class="col-sm-12">
-                                <input   type="text" title="Endereço da rua" name="billing[street][0]" id="billing:street1" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(1)) ?>" class=" form-control   required-entry  validate-length minimum-length-4 maximum-length-65" placeholder="Endereço">
+                                <input type="text" title="Endereço da rua" name="billing[street][0]" id="billing:street1" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(1)) ?>" class=" form-control   required-entry  validate-length minimum-length-4 maximum-length-57" placeholder="Endereço">
                           </div>
                     </div>
                 </div>

--- a/app/design/frontend/base/default/template/MOIP/onestepcheckout/editaddress/billing/billingform.phtml
+++ b/app/design/frontend/base/default/template/MOIP/onestepcheckout/editaddress/billing/billingform.phtml
@@ -205,7 +205,7 @@
                     <div class="form-group">
                           <label class="col-sm-12 control-label" for="textinput">Número</label>
                           <div class="col-sm-12">
-                                <input   type="tel" title="Número" name="billing[street][1]" id="billing:street2" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(2)) ?>" class=" form-control   required-entry  validate-length minimum-length-1 maximum-length-5" placeholder="Número">
+                                <input type="tel" title="Número" name="billing[street][1]" id="billing:street2" value="<?php echo $this->htmlEscape($this->getAddress()->getStreet(2)) ?>" class="form-control required-entry validate-length minimum-length-1 maximum-length-6" placeholder="Número">
                           </div>
                     </div>
                 </div>


### PR DESCRIPTION
Desenvolvo lojas virtuais e já tive que fazer essas alterações para 4 projetos diferentes.

57 caracteres no campo de rua é o mais importante dessa alteração. Já existe ruas com mais caracteres do que o limite atual de 45 caracteres. (como exemplo: Avenida Engenheiro Luis Gomes Cardim Sangirardi - São Paulo)

Edit: A busca de endereço retorna um nome de rua de 48 caracteres com o CEP 91370-170: Avenida Dom Cláudio José Gonçalves Ponce de Leão